### PR TITLE
Switch to SDL2 for Mupen64Plus 2.1

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -220,13 +220,23 @@ LDLIBS += $(GL_LDLIBS)
 
 # test for presence of SDL
 ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
-  SDL_CONFIG = $(CROSS_COMPILE)sdl-config
+  SDL_CONFIG = $(CROSS_COMPILE)sdl2-config
   ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-    $(error No SDL development libraries found!)
+    $(warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!)
+    $(warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!)
+    $(warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!)
+    $(warning $(SDL_CONFIG) not found! Falling back to deprecated sdl-config)
+    $(warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!)
+    $(warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!)
+    $(warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!)
+    SDL_CONFIG = $(CROSS_COMPILE)sdl-config
+    ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
+      $(error No SDL development libraries found!)
+    endif
   endif
   ifeq ($(OS),OSX)
     SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
-    # sdl-config on mac screws up when we're trying to build a library and not an executable
+    # sdl2-config on mac screws up when we're trying to build a library and not an executable
     # SDL 1.3 is supposed to fix that, if it's ever released
     SDL_LDLIBS += -L/usr/local/lib -lSDL -Wl,-framework,Cocoa
   else


### PR DESCRIPTION
The current version of SDL is 2.0.3. All new releases of distributions contain
this library already. Current Linux distributions and *BSD even backporting
patches from Mupen64Plus 2.1 repo to use SDL 2. Android and other mobile
platform don't have support for legacy SDL 1.2.

People like Anthony J. Bentley and Riley Labrecque already requested
a new release of Mupen64Plus 2.1 with SDL2