### PR TITLE
fix missing SDL2 test

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -219,16 +219,25 @@ LDLIBS += $(GL_LDLIBS)
 
 # test for presence of SDL
 ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
-  SDL_CONFIG = $(CROSS_COMPILE)sdl-config
+  SDL_CONFIG = $(CROSS_COMPILE)sdl2-config
   ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-    $(error No SDL development libraries found!)
-  endif
-  ifeq ($(OS),OSX)
-    SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
-    # sdl-config on mac screws up when we're trying to build a library and not an executable
-    # SDL 1.3 is supposed to fix that, if it's ever released
-    SDL_LDLIBS += -L/usr/local/lib -lSDL -Wl,-framework,Cocoa
+    SDL_CONFIG = $(CROSS_COMPILE)sdl-config
+    ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
+      $(error No SDL development libraries found!)
+    else
+      $(warning Using SDL 1.2 libraries)
+      ifeq ($(OS),OSX)
+        SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
+        # sdl-config on mac screws up when we're trying to build a library and not an executable
+        # SDL 1.3 is supposed to fix that, if it's ever released
+        SDL_LDLIBS += -L/usr/local/lib -lSDL -Wl,-framework,Cocoa
+      else
+        SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
+        SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
+      endif
+    endif
   else
+    #SDL2 detected
     SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
     SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
   endif


### PR DESCRIPTION
Test for SDL2 developed library is missing in Makefile. Added test for SDL2 in similar way that is implemented in the others Makefiles.
Please check if the code is useful. :-)
