### PR TITLE
Fix linux build issue.

### DIFF
--- a/src/glshader.cpp
+++ b/src/glshader.cpp
@@ -35,9 +35,6 @@
 #include <glext.h>
 #else
 #include <GL/gl.h>
-#ifndef WIN32
-    #include <GL/glext.h>
-#endif
 #endif
 #include "glshader.h"
 


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-user-issues/issues/704.

Please review this to make sure its right. The header `GL/glext.h` is part of the mesa package here and I tested building mupen64plus-video-z64 on Slackware64-current with `Mesa 18.3.0-devel (git-de57926dc9)` and Slackware64 14.2 with `mesa-11.2.2` without issues.