### PR TITLE
Don't include gl headers at all. GLEW already takes care of that.

### DIFF
--- a/src/glshader.cpp
+++ b/src/glshader.cpp
@@ -20,6 +20,7 @@
 **/
 
 #include <GL/glew.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -27,18 +28,6 @@
 #include "m64p_types.h"
 #include "rdp.h"
 #include "rgl_assert.h"
-#if defined(__MACOSX__)
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#elif defined(__MACOS__)
-#include <gl.h>
-#include <glext.h>
-#else
-#include <GL/gl.h>
-#ifndef WIN32
-    #include <GL/glext.h>
-#endif
-#endif
 #include "glshader.h"
 
 static void printInfoLog(GLhandleARB obj, const char * src)

--- a/src/rgl.h
+++ b/src/rgl.h
@@ -29,13 +29,6 @@
 #include "queue.h"
 #include "rdp.h"
 #include "rgl_assert.h"
-#if defined(__MACOSX__)
-#include <OpenGL/gl.h>
-#elif defined(__MACOS__)
-#include <gl.h>
-#else
-#include <GL/gl.h>
-#endif
 
 #ifdef RDP_DEBUG
 //#include <IL/il.h>


### PR DESCRIPTION
See https://www.khronos.org/opengl/wiki/OpenGL_Loading_Library#GLEW_.28OpenGL_Extension_Wrangler.29

Fixes #15 