### PR TITLE
CI/CD: Integrate scheduled builds and other necessary updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ on:
       - '**/*.md'
       - '.{gitattributes,gitignore,travis.yml}'
       - 'appveyor.yml,README'
+  schedule:
+    - cron: '5 14 21 * *'
   workflow_dispatch:
+
 jobs:
 
   Linux:
@@ -33,22 +36,30 @@ jobs:
             bits: 32
     name: Linux / ${{ matrix.cc }} / ${{ matrix.platform }}
     runs-on: ubuntu-22.04
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-z64') || (github.event_name != 'schedule')
     steps:
       - uses: actions/checkout@v3
       - name: Get build dependencies and arrange the environment
         run: |
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then
-            echo "NOTE: There is no native \"libglew2.2:i386\" in Ubuntu 22.04, we will FORCE one from Debian..."
-            echo ""
-            sudo dpkg --add-architecture i386
-          fi
+          echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then sudo dpkg --add-architecture i386; fi
           sudo apt-get update
           sudo apt-get -y install libgl1-mesa-dev libglew-dev libsdl1.2-dev libsdl2-dev
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then
             sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386 libgl1-mesa-glx:i386 libglu1-mesa:i386 libsdl1.2debian:i386 libsdl2-2.0-0:i386 libx11-6:i386
-            curl -L -o /tmp/libglew2.2_2.2.0-4_i386.deb http://http.us.debian.org/debian/pool/main/g/glew/libglew2.2_2.2.0-4_i386.deb
-            dpkg-deb -x /tmp/libglew2.2_2.2.0-4_i386.deb /tmp/i386/
-            sudo cp -r /tmp/i386/usr/lib/i386-linux-gnu/libGLEW.so.* /usr/lib/i386-linux-gnu/
+            echo ""
+            echo "NOTE: There is no native \"libglew2.2:i386\" in Ubuntu 22.04, we will use Debian ones..."
+            echo ""
+            DEBSOURCE="http://http.us.debian.org/debian/pool/main/g/glew/"
+            PKGVER_LS="$(curl -sS ${DEBSOURCE} | grep 'dev_2.2' | grep 'amd64' | cut -d '_' -f2 | sort)"
+            if [[ "${PKGVER_LS}" != "" ]]; then
+              for VER in ${PKGVER_LS}; do PKGVER="${VER}"; done
+              cd /tmp
+              curl -L -O "${DEBSOURCE}libglew-dev_${PKGVER}_amd64.deb"
+              curl -L -O "${DEBSOURCE}libglew2.2_${PKGVER}_amd64.deb"
+              curl -L -O "${DEBSOURCE}libglew2.2_${PKGVER}_i386.deb"
+              sudo dpkg -i libglew*${PKGVER}*.deb
+            fi
             LINK="sudo ln -s -T"
             cd /usr/lib/i386-linux-gnu
             if ! [[ -f libGL.so ]]; then ${LINK} libGL.so.1.7.0 libGL.so; fi
@@ -61,27 +72,23 @@ jobs:
             if ! [[ -f _real_SDL_config.h ]]; then ${LINK} ../x86_64-linux-gnu/SDL2/_real_SDL_config.h _real_SDL_config.h; fi
           fi
           sudo ldconfig
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
-          G_REV=$(git rev-parse --short HEAD)
-          echo "G_REV=${G_REV}" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1" CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
-          if [[ "${{ matrix.cc }}" == "GCC" ]]; then
-            CC="gcc"
-            CXX="g++"
-          else
+          CC="gcc"
+          CXX="g++"
+          if [[ "${{ matrix.cc }}" != "GCC" ]]; then
             CC="clang"
             CXX="clang++"
           fi
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1"; fi
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
           MSG="1.2"
-          mkdir tmp
-          for SDL in sdl sdl2
-          do
+          mkdir pkg
+          for SDL in sdl sdl2; do
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL${MSG} ::"
             echo ""
@@ -89,22 +96,20 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" SDL_CONFIG="${SDL}-config" -C projects/unix all -j4
             echo ""
-            make -C projects/unix install DESTDIR="${ORIG}/tmp"
+            make -C projects/unix install DESTDIR="${ORIG}/pkg/"
             echo ""
-            cd tmp/usr/local/lib/mupen64plus
-            ls -gG *.so
-            ldd mupen64plus-video-z64.so
+            ls -gG pkg/usr/local/lib/mupen64plus/*.so
+            echo ""
+            ldd pkg/usr/local/lib/mupen64plus/mupen64plus-video-z64.so
             MSG="2"
-            cd "${ORIG}"
           done
-          mkdir pkg
-          if [[ "${CC}" == "gcc" ]]; then tar cvzf pkg/mupen64plus-video-z64-${{ matrix.platform }}-g${G_REV}.tar.gz -C tmp/ "usr"; fi
+          tar cvzf pkg/mupen64plus-video-z64-linux-${{ matrix.platform }}-g${{ env.G_REV }}.tar.gz -C pkg/ "usr"
       - name: Upload artifact
+        if: matrix.cc == 'GCC'
         uses: actions/upload-artifact@v3
         with:
-          name: mupen64plus-video-z64-${{ matrix.platform }}-g${{ env.G_REV }}
-          path: pkg/*
-          if-no-files-found: ignore
+          name: mupen64plus-video-z64-linux-${{ matrix.platform }}-g${{ env.G_REV }}
+          path: pkg/*.tar.gz
 
   MSYS2:
     strategy:
@@ -120,7 +125,8 @@ jobs:
             cross: i686
             bits: 32
     name: Windows / MSYS2 ${{ matrix.cc }} / ${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2022
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-z64') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: msys2 {0}
@@ -138,17 +144,18 @@ jobs:
             mingw-w64-${{ matrix.cross }}-toolchain
             mingw-w64-${{ matrix.cross }}-glew
             mingw-w64-${{ matrix.cross }}-SDL2
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
           echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
           CC="gcc"
           CXX="g++"
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
-          mkdir tmp
+          mkdir pkg
           echo ""
           echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL2 ::"
           echo ""
@@ -156,24 +163,17 @@ jobs:
           echo ""
           make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" -C projects/unix all -j4
           echo ""
-          make -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/tmp"
+          make -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/pkg/"
           echo ""
-          ls -gG tmp/*.dll
-          ldd tmp/mupen64plus-video-z64.dll
-      - name: Copy binaries, dependencies, etc...
+          ls -gG pkg/*.dll
+          echo ""
+          ldd pkg/mupen64plus-video-z64.dll
+      - name: Backup dependencies, etc...
         run: |
-          mkdir pkg
           if [[ ${{ matrix.bits }} -eq 32 ]]; then LIBGCC="libgcc_s_dw2-1"; else LIBGCC="libgcc_s_seh-1"; fi
-          for LIB in glew32 ${LIBGCC} libwinpthread-1 SDL2
-          do
+          for LIB in glew32 ${LIBGCC} libwinpthread-1 SDL2; do
             echo ":: Copying ${LIB}.dll"
             cp "/mingw${{ matrix.bits }}/bin/${LIB}.dll" pkg/
-          done
-          cd tmp
-          for BIN in *.dll
-          do
-            echo ":: Copying ${BIN}"
-            cp "${BIN}" ../pkg/
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -183,8 +183,8 @@ jobs:
 
   Nightly-build:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'master'
     needs: [Linux, MSYS2]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts
@@ -199,8 +199,7 @@ jobs:
         run: |
           mkdir pkg
           cd binaries
-          for BIN in *
-          do
+          for BIN in *; do
             cd "${BIN}"
             if [[ "${BIN:22:4}" == "msys" ]]; then
               echo ":: Creating ${BIN}.zip"
@@ -213,10 +212,9 @@ jobs:
           done
           cd ../pkg
           echo ""
-          for BIN in *
-          do
+          for BIN in *; do
             ls -gG ${BIN}
-            tigerdeep -l ${BIN} >> ../${BIN:0:21}.tiger.txt
+            tigerdeep -lz ${BIN} >> ../${BIN:0:21}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:21}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:21}.sha512.txt
           done


### PR DESCRIPTION
Relevant changes:

- Schedule builds at least once a month (upstream only)
- Less hackish solution for `libglew2.2:i386`...
- Update some GitHub Actions values
- Bash code simplification and corrections
- Optimize x86 builds with SSE2 on Linux and MSYS2 (sometimes not effective)
- Tag to Linux binaries
- Add file size to tiger hashfile